### PR TITLE
Fix documentation issues based on feedback

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -7,19 +7,24 @@ An Agentic Development Environment for Claude Code that provides visual task man
 ### Requirements
 
 **Required:**
-- **Node.js 22+** and **npm 10+**
-- **Claude Code CLI** - Active subscription and installed CLI
-- **Git** - For repository management
 
-**Recommended:**
-- **Java 17+** - For SonarQube for IDE code analysis
-- **jq** - JSON processing tool for CLI hooks
+- **Node.js 22+** and **npm 10+** - [Download Node.js](https://nodejs.org/)
+- **Claude Code CLI** - Active subscription and installed CLI - [Get Claude Code](https://claude.ai/download)
+- **Git** - For repository management - [Download Git](https://git-scm.com/downloads)
+- **Java 17+** - Required for SonarQube for IDE code analysis - [Download OpenJDK](https://openjdk.org/) or [Oracle JDK](https://www.oracle.com/java/technologies/downloads/)
+
+!!! warning "Platform Support"
+    Currently only **macOS** is supported. Windows and Linux support coming soon.
+
+!!! warning "x64 Architecture Limitation"
+    On x64 (Intel) Macs, SonarQube Context Augmentation features will not work. Full functionality requires Apple Silicon (ARM64).
 
 ### What is Kintsugi?
 
 Kintsugi is a desktop application that extends Claude Code with visual task management and automated code quality checks. It works by installing CLI hooks that interact with a local database to track your development workflow.
 
 **Key capabilities:**
+
 - Automatic task tracking as you work with Claude Code
 - Visual Kanban board for managing development workflow
 - Code quality analysis with SonarQube for IDE integration
@@ -29,31 +34,30 @@ Kintsugi is a desktop application that extends Claude Code with visual task mana
 
 ### Installation
 
-=== "macOS"
-    Download the `.dmg` installer, drag to Applications, and launch.
-
-=== "Windows"
-    Download the `.exe` installer and follow the installation wizard.
-
-=== "Linux"
-    Download the `.AppImage`:
-    ```bash
-    chmod +x Kintsugi-x.y.z.AppImage
-    ./Kintsugi-x.y.z.AppImage
-    ```
+Download the `.dmg` installer for macOS, drag to Applications, and launch.
 
 ### Setup
 
 On first launch, Kintsugi will guide you through:
 
 1. **CLI hooks installation** - Registers hooks in `~/.claude/settings.json` to capture Claude Code events
-2. **Repository selection** - Choose a Git repository to track
-3. **Optional integrations** - Configure SonarQube, JIRA, or GitHub (can be skipped)
+2. **Repository folder selection** - Select the folder where your Git repositories are located
+3. **Optional integrations** - Configure SonarQube or JIRA (can be skipped)
 
 The setup process creates:
+
 - Local backend server on port 63421
 - SQLite database at `~/.kintsugi/local.db`
 - Configuration files in `~/.kintsugi/`
+
+**Manual plugin installation:**
+
+If the automatic installation fails, you can install the plugin manually:
+
+```bash
+npm install -g @kintsugi/plugin
+kintsugi register-hooks
+```
 
 ### First Session
 
@@ -114,23 +118,17 @@ Verify Java installation:
 java --version  # Should be 17+
 ```
 
-Check if port 8765 is available:
-```bash
-lsof -i :8765
-```
-
 If Java is not found, install it:
+
 - macOS: `brew install openjdk@17`
-- Linux: `apt-get install openjdk-17-jdk`
-- Windows: Download from Oracle or OpenJDK
 
-**Analysis fails or times out**
+Download from [OpenJDK](https://openjdk.org/) or [Oracle JDK](https://www.oracle.com/java/technologies/downloads/)
 
-Increase analysis timeout in Settings → Code Analysis → Analysis Timeout (default is 120s, try 300s).
+**Analysis fails**
 
 Check available system resources. Large files may require more memory.
 
-Restart SonarLint bridge from Settings → SonarQube for IDE → Restart Bridge.
+Restart the Kintsugi application to reinitialize the SonarLint bridge.
 
 ### Application Issues
 
@@ -140,14 +138,14 @@ If you install Java while Kintsugi is running, the application won't detect it a
 
 **Hooks not firing / Tasks not appearing**
 
-Verify hooks are registered:
+Verify hooks are registered using Claude Code:
 ```bash
-cat ~/.claude/settings.json | jq .hooks
+claude /plugin
 ```
 
 Re-register hooks if needed:
 ```bash
-kintsugi unregister-hooks
+npm install -g @kintsugi/plugin
 kintsugi register-hooks
 ```
 
@@ -163,32 +161,25 @@ curl http://localhost:63421/health
 
 **High memory usage**
 
-Archive old completed tasks (Settings → Tasks → Archive).
-
-Reduce terminal scrollback: Settings → Terminal → Scrollback Lines.
-
 Vacuum database periodically:
 ```bash
 sqlite3 ~/.kintsugi/local.db "VACUUM"
 ```
 
+Delete old tasks from the UI to reduce database size.
+
 **Desktop app won't launch**
 
-Clear cache:
+Try deleting the SQLite database (this will remove all tasks):
 ```bash
-rm -rf ~/.kintsugi/cache/
+rm ~/.kintsugi/local.db
 ```
 
-Reset settings (creates backup):
-```bash
-mv ~/.kintsugi/desktop-config.json ~/.kintsugi/desktop-config.json.backup
-```
+Restart Kintsugi to create a fresh database.
 
 **Terminal not working**
 
-Try a different shell in Settings → Terminal → Shell (bash vs zsh).
-
-Reset terminal settings: Settings → Terminal → Reset Defaults.
+Close and reopen the terminal panel. If issues persist, restart the Kintsugi application.
 
 **Diffs not generating**
 
@@ -213,9 +204,10 @@ claude --version
 ```
 
 **Review logs:**
+
 - Backend: `~/.kintsugi/local-backend.log`
 - Hooks: `~/.kintsugi/hook-debug.log`
-- Application: Check DevTools (Cmd/Ctrl+Shift+I) Console tab
+- Application: Check DevTools (Cmd+Shift+I) Console tab
 
 **Report issues:**
 


### PR DESCRIPTION
- Fixed markdown list formatting (added blank lines before lists)
- Changed Java to required (not recommended)
- Removed jq from requirements
- Added download links for all required tools
- Added macOS-only platform support warning
- Added x64 architecture limitation warning for SonarQube
- Fixed repository selection description (folder location, not single repo)
- Removed GitHub integration references
- Added manual plugin installation instructions
- Removed non-existent settings (analysis timeout, SonarLint restart)
- Changed hook verification to use 'claude /plugin' command
- Removed incorrect troubleshooting steps (cache, config backups, terminal settings)