### PR TITLE
Remove Discord Community from social links

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -131,9 +131,6 @@ extra:
     - icon: fontawesome/brands/github
       link: https://github.com/SonarSource/kintsugi-docs
       name: GitHub
-    - icon: fontawesome/brands/discord
-      link: https://discord.gg/sonarsource
-      name: Discord Community
   version:
     provider: mike
   status:


### PR DESCRIPTION
Removed Discord Community link from social section.